### PR TITLE
use root environment.yml instead of .binder/environment.yml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -24,3 +24,7 @@ dependencies:
   - python=3.13.3
   - matplotlib=3.10.1
   - seaborn=0.13.2
+  - r-base>=4.2         # for binder: R base packages
+  - r-essentials        # for binder: IRkernel + common R packages
+  - r-devtools          # for binder: Provides devtools::install_github()
+  - jupyterlab          # for binder: JupyterLab option


### PR DESCRIPTION
Since have `environment.yml` in repo root, Binder uses that file and ignores `.binder/environment.yml`.