### PR TITLE
Update R version in deploy-quarto.yml to 4.4 and add conda env step

### DIFF
--- a/.github/workflows/deploy-quarto.yml
+++ b/.github/workflows/deploy-quarto.yml
@@ -17,12 +17,20 @@ jobs:
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: '4.3'
+          r-version: '4.4'
 
       - name: Install renv and restore
         run: |
           Rscript -e 'install.packages("renv", repos="https://cloud.r-project.org")'
           Rscript -e 'renv::restore()'
+
+      - name: Set up conda environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          channels: conda-forge, defaults
+          activate-environment: diverse_web_env
+          environment-file: environment.yml
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
R version 4.4 is necessary for the `MASS` package (the workflow failed to run [this time](https://github.com/diverse-data-hub/diverse-data-hub.github.io/actions/runs/16816473101/job/47634370724) because of this).
The conda environment is to ensure that the workflow can run the python code via `quarto render`